### PR TITLE
Always put channels from `--channels` on top of package's `condarc`

### DIFF
--- a/conda_build_prepare/__main__.py
+++ b/conda_build_prepare/__main__.py
@@ -49,7 +49,7 @@ if __name__ == '__main__':
     if args.channels is not None:
         env_settings['prepend'] = { 'channels': args.channels }
 
-    prepare_environment(recipe_dir, env_dir, args.packages or [], env_settings)
+    prepare_environment(recipe_dir, env_dir, args.packages or [], env_settings, args.channels or [])
 
     prepare_recipe(recipe_dir, git_dir, env_dir)
 


### PR DESCRIPTION
The `litex-conda-*` CIs are happy with such change (tested before squashing the commits but code hasn't changed):
* https://github.com/litex-hub/litex-conda-compilers/actions/runs/498033515
* https://github.com/litex-hub/litex-conda-eda/actions/runs/496613688
* https://github.com/litex-hub/litex-conda-misc/actions/runs/498015331
* https://github.com/litex-hub/litex-conda-prog/actions/runs/498241037

The most important is successful CI in the `litex-conda-compilers` repository because there was an issue with `gcc/newlib` and `gcc/musl` caused precisely by making one of the channels passed with `--channels` less important than the ones from the `condarc`: https://github.com/litex-hub/litex-conda-compilers/issues/13 .

The two failures in the `litex-conda-eda` repository aren't caused by this change because they are also observed in Ci runs from other branches that didn't change anything in the CI itself like https://github.com/litex-hub/litex-conda-eda/actions/runs/498053715