### PR TITLE
Don't prefix versions with `v`

### DIFF
--- a/conda_build_prepare/git_helpers.py
+++ b/conda_build_prepare/git_helpers.py
@@ -222,7 +222,7 @@ def tag_extract_version(tag):
         return None
     else:
         version_found = version_search.group(0)
-        return f'v{version_found}'
+        return version_found
 
 
 def git_rewrite_tags(git_repo):


### PR DESCRIPTION
This change is motivated by the Anaconda package repository's preference
logic. Because of that logic uploaded packages that have a version
starting with a number are always preferred over those that have a
version starting with `v`.

Therefore if the package X previously had version like `1.2.3` and the
newer version is `v1.5.8` then the `conda install X` command will
install the `X-1.2.3` package. This is the case of many packages
currently built with `conda-build-prepare`.