### PR TITLE
Provide default values for DATE_NUM and DATE_STR

### DIFF
--- a/conda_build_prepare/git_helpers.py
+++ b/conda_build_prepare/git_helpers.py
@@ -131,14 +131,15 @@ def fetch_tags(**env):
     subprocess.check_call(['git', 'fetch', '--tags'], env=env)
 
 
-def _call_custom_git_cmd(git_repo, cmd_string, quiet=False):
+def _call_custom_git_cmd(git_repo, cmd_string, check=True, quiet=False):
     cmd = cmd_string.split()
     if cmd[0] != 'git':
         cmd.insert(0, 'git')
 
-    stdout = subprocess.check_output(cmd, cwd=git_repo, encoding='utf-8',
+    stdout = subprocess.run(cmd, check=check, cwd=git_repo, encoding='utf-8',
             # None means "don't capture"
-            stderr=subprocess.DEVNULL if quiet else None)
+            stderr=subprocess.DEVNULL if quiet else None,
+            stdout=subprocess.PIPE).stdout
     return stdout.strip()
 
 

--- a/conda_build_prepare/git_helpers.py
+++ b/conda_build_prepare/git_helpers.py
@@ -5,6 +5,8 @@ import re
 import subprocess
 import urllib.parse
 
+from datetime import datetime, timezone
+
 GITHUB_RE = re.compile("github.com[:/](?P<user>[^/\n]+)(/(?P<repo>[^/.].*?))?(.git|/|$)")
 
 def extract_github_parts(url):
@@ -289,6 +291,17 @@ def git_clone_relative_submodules(git_repo, git_url):
 
 def git_checkout(git_repo, revision):
     _call_custom_git_cmd(git_repo, f'checkout {revision}')
+
+
+def git_get_head_time(git_repo):
+    timestamp_str = _call_custom_git_cmd(git_repo, 'git log --format=%ct -n1')
+    return datetime.fromtimestamp(int(timestamp_str), timezone.utc)
+
+
+def is_inside_git_repo(path):
+    git_cmd = 'git rev-parse --is-inside-work-tree'
+    git_stdout = _call_custom_git_cmd(path, git_cmd, check=False, quiet=True)
+    return git_stdout == 'true'
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
These variables are used by many LiteX-Hub recipes.

It seems reasonable to not require setting them locally from users.

For the latest conda-build-prepare commit such values are set by the
`_set_date_env_vars` function:
* `DATE_NUM=20210120162445`
* `DATE_STR=20210120_162445`