### PR TITLE
Print stdout if check_output's subprocess fails

### DIFF
--- a/conda_build_prepare/prepare.py
+++ b/conda_build_prepare/prepare.py
@@ -61,8 +61,8 @@ def get_package_condarc(recipe_dir):
         return None
 
 
-def write_metadata(package_dir, recipe_dir):
-    metadata_file = os.path.join(package_dir, 'recipe_append.yaml')
+def write_metadata(new_recipe_dir, original_recipe_dir):
+    metadata_file = os.path.join(new_recipe_dir, 'recipe_append.yaml')
 
     metadata = {
         'extra': {
@@ -72,7 +72,8 @@ def write_metadata(package_dir, recipe_dir):
 
     def _try_to_get_git_output(cmd_string):
         try:
-            return _call_custom_git_cmd(recipe_dir, cmd_string, quiet=True)
+            return _call_custom_git_cmd(original_recipe_dir, cmd_string,
+                    quiet=True)
         except subprocess.CalledProcessError:
             return 'GIT_ERROR'
 
@@ -127,7 +128,7 @@ def write_metadata(package_dir, recipe_dir):
     if toolchain_arch is not None:
         metadata['extra']['toolchain_arch'] = toolchain_arch
 
-    package_condarc = get_package_condarc(package_dir)
+    package_condarc = get_package_condarc(new_recipe_dir)
     if package_condarc is not None:
         with open(package_condarc, 'r') as condarc_file:
             condarc = YAML().load(condarc_file)
@@ -166,14 +167,14 @@ def _set_date_env_vars(recipe_dir):
         _set_env_var('DATE_NUM', date_num)
         print()
 
-def prepare_directory(package_dir, dest_dir):
-    assert os.path.exists(package_dir)
+def prepare_directory(recipe_dir, dest_dir):
+    assert os.path.exists(recipe_dir)
     assert not os.path.exists(dest_dir)
 
     # Set DATE_NUM and DATE_STR environment variables used by many recipes
-    _set_date_env_vars(package_dir)
+    _set_date_env_vars(recipe_dir)
 
-    shutil.copytree(package_dir, dest_dir)
+    shutil.copytree(recipe_dir, dest_dir)
 
     # Prescript
 

--- a/conda_build_prepare/prepare.py
+++ b/conda_build_prepare/prepare.py
@@ -61,7 +61,7 @@ def get_package_condarc(recipe_dir):
         return None
 
 
-def write_metadata(package_dir):
+def write_metadata(package_dir, recipe_dir):
     metadata_file = os.path.join(package_dir, 'recipe_append.yaml')
 
     metadata = {
@@ -72,7 +72,7 @@ def write_metadata(package_dir):
 
     def _try_to_get_git_output(cmd_string):
         try:
-            return _call_custom_git_cmd('.', cmd_string, quiet=True)
+            return _call_custom_git_cmd(recipe_dir, cmd_string, quiet=True)
         except subprocess.CalledProcessError:
             return 'GIT_ERROR'
 
@@ -186,7 +186,7 @@ def prepare_directory(package_dir, dest_dir):
                 shell=sys.platform in ['cygwin', 'msys', 'win32'])
         print('\nFinished executing prescript.\n')
 
-    write_metadata(dest_dir)
+    write_metadata(dest_dir, recipe_dir)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The first and second commit only contain minor fixes. The third commit is crucial.

`stdout` is captured while calling commands with `check_output`. The default exception doesn't even mention what the command has printed to `stdout` even though it is available in the CalledProcessError instance.

This is especially important for Conda as it sometimes prints errors to *stdout*. Not printing it can significantly slow down fixing recipe problems. It's definitely true in case of a recipe source patching problems.

For example, after purposefully breaking `magic` patch only the output added in this PR contains a more precise clue what went wrong. Information above (Conda *stderr*) and below (Python exception) aren't very helpful:

```
Error: Failed to render jinja template in new/recipe/meta.yaml:
'GIT_DESCRIBE_NUMBER' is undefined

!! =======================================================
!! ERROR: conda-build-prepare subprocess failed!
!!
!! Command called: conda run -p new/conda-env conda render -f new/recipe/rendered_metadata.yaml new/recipe
!! 
!! STDERR not captured; look above for errors too! STDOUT:
!!
Warning: failed to download source.  If building, will try again after downloading recipe dependencies.
Error was: 
Command '['/usr/bin/patch', '--no-backup-if-mismatch', '--batch', '-Np1', '-i', '/tmp/tmpi4plj9m8/csh.patch.native', '--binary', '--dry-run']' returned non-zero exit status 1.
!! 
!! =======================================================

Error during package metadata rendering!
Traceback (most recent call last):
  File "miniconda3/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "miniconda3/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "conda_build_prepare/__main__.py", line 54, in <module>
    prepare_recipe(recipe_dir, git_dir, env_dir)
  File "conda_build_prepare/conda_cmds.py", line 374, in prepare_recipe
    meta = render_metadata(package_dir, env_dir)
  File "conda_build_prepare/conda_cmds.py", line 59, in render_metadata
    _call_conda_cmd_in_env(f"conda render -f {rendered_path} {package_dir}", env_dir)
  File "conda_build_prepare/conda_cmds.py", line 177, in _call_conda_cmd_in_env
    return _check_output(f'conda run -p {env_path} {cmd_string}')
  File "conda_build_prepare/conda_cmds.py", line 158, in _check_output
    **kwargs).strip()
  File "miniconda3/lib/python3.7/subprocess.py", line 411, in check_output
    **kwargs).stdout
  File "miniconda3/lib/python3.7/subprocess.py", line 512, in run
    output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['conda', 'run', '-p', 'new/conda-env', 'conda', 'render', '-f', 'new/recipe/rendered_metadata.yaml', 'new/recipe']' returned non-zero exit status 1.
```