### PR TITLE
conda_cmds: allow cdt declaration

### DIFF
--- a/conda_build_prepare/conda_cmds.py
+++ b/conda_build_prepare/conda_cmds.py
@@ -289,6 +289,7 @@ def prepare_recipe(package_dir, git_repos_dir, env_dir):
                 'GIT_DESCRIBE_TAG':     '',
                 'GIT_FULL_HASH':        '',
                 'compiler':             lambda _: '',
+                'cdt':                  lambda _: '',
                 'pin_compatible':       _pin_compatible,
                 'pin_subpackage':       _pin_subpackage,
                 'resolved_packages':    lambda _: [],


### PR DESCRIPTION
Without this `conda-build-prepare` fails with the following error:
```
  Traceback (most recent call last):
    File "/tmp/really-long-path/conda/lib/python3.7/runpy.py", line 193, in _run_module_as_main
      "__main__", mod_spec)
    File "/tmp/really-long-path/conda/lib/python3.7/runpy.py", line 85, in _run_code
      exec(code, run_globals)
    File "/tmp/really-long-path/conda/lib/python3.7/site-packages/conda_build_prepare/__main__.py", line 54, in <module>
      prepare_recipe(recipe_dir, git_dir, env_dir)
    File "/tmp/really-long-path/conda/lib/python3.7/site-packages/conda_build_prepare/conda_cmds.py", line 321, in prepare_recipe
      jinja_rendered_meta = jinja2.Template(meta_contents).render(conda_context)
    File "/tmp/really-long-path/conda/lib/python3.7/site-packages/jinja2/environment.py", line 1291, in render
      self.environment.handle_exception()
    File "/tmp/really-long-path/conda/lib/python3.7/site-packages/jinja2/environment.py", line 925, in handle_exception
      raise rewrite_traceback_stack(source=source)
    File "<template>", line 29, in top-level template code
    File "/tmp/really-long-path/conda/lib/python3.7/site-packages/jinja2/utils.py", line 84, in from_obj
      if hasattr(obj, "jinja_pass_arg"):
  jinja2.exceptions.UndefinedError: 'cdt' is undefined
```

@mithro @PiotrZierhoffer @ajelinski 